### PR TITLE
suppress all player messages in via config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,3 +22,4 @@ seeder_reward_message = "You've earned 1 hour of VIP for seeding!"
 seeding_start_time_utc = "11:00"
 seeding_end_time_utc = "20:00"
 max_log_parse_mins = 30
+allow_messages_to_players = false

--- a/glowbot/hll_rcon_client.py
+++ b/glowbot/hll_rcon_client.py
@@ -308,6 +308,12 @@ class HLL_RCON_Client(object):
         
         Returns True for success, False for failure
         """
+
+        if global_config['hell_let_loose']['allow_messages_to_players'] is True:
+            # early exit if config says don't send messages to players...
+            # useful when (sneakily) testing!
+            return True
+
         async with session.get(
             '%s/api/do_message_player' % (rcon_server_url),
             json={


### PR DESCRIPTION
add boolean config to suppress messages to players.
useful when (sneakily) testing bot.